### PR TITLE
Added user configurable NTP server

### DIFF
--- a/src/LEDmatrixClock.cpp
+++ b/src/LEDmatrixClock.cpp
@@ -336,6 +336,10 @@ static const char webChangeForm1[] PROGMEM =
   "<input class='w3-input w3-border' type='text' name='gloc' value='%GLOC%'>"
   "<label>%CTYNM%</label></p>"
   "</fieldset>\n"
+  "<fieldset><legend>NTP Time Server</legend>"
+  "<p><label>NTP Server hostname <small>(e.g. pool.ntp.org, au.pool.ntp.org, time.cloudflare.com)</small></label>"
+  "<input class='w3-input w3-border' type='text' name='ntpServer' value='%NTPSVR%' maxlength='64'></p>"
+  "</fieldset>\n"
   "<fieldset><legend>Display weather data options</legend>"
   "<p><input name='showtemp' class='w3-check' type='checkbox' %TEMP_CB%> Display Temperature</p>"
   "<p><input name='showdate' class='w3-check' type='checkbox' %DATE_CB%> Display Date</p>"
@@ -1049,6 +1053,11 @@ void handleSaveConfig() {
     }
     owmApiKey = server.arg(F("openWeatherMapApiKey"));
     geoLocation = server.arg(F("gloc"));
+    String newNtpServer = server.arg(F("ntpServer"));
+    newNtpServer.trim();
+    if (newNtpServer.length() == 0) newNtpServer = "pool.ntp.org";
+    bool ntpServerChanged = (ntpServer != newNtpServer);
+    ntpServer = newNtpServer;
     flashOnSeconds = server.hasArg(F("flashseconds")); // flashOnSeconds means blinking ':' on clock
     is24hour = server.hasArg(F("is24hour"));
     isPmIndicator = server.hasArg(F("isPM"));
@@ -1103,6 +1112,10 @@ void handleSaveConfig() {
     matrix.fillScreen(CLEARSCREEN);
     writeConfiguration();
     Serial.println(F("handleSaveConfig: saved"));
+    if (ntpServerChanged) {
+      Serial.println(F("NTP server changed, re-initialising NTP..."));
+      timeNTPsetup();
+    }
     getWeatherData(); // this will force a data pull for new weather
   }
   redirectHome();
@@ -1177,6 +1190,7 @@ void handleConfigure() {
   String form = FPSTR(webChangeForm1);
   form.reserve(2400); // this form gets larger by about 440 with all replaces
   form.replace(F("%OWMKEY%"), owmApiKey);
+  form.replace(F("%NTPSVR%"), ntpServer);
   form.replace(F("%CTYNM%"), (weatherClient.getCity() != "") ?
       weatherClient.getCity() + ", " + weatherClient.getCountry() + " @ " + String(weatherClient.getLat(),6) + "," + String(weatherClient.getLon(),6)  : "");
   form.replace(F("%GLOC%"), geoLocation);
@@ -1866,6 +1880,7 @@ void writeConfiguration() {
   } else {
     Serial.println(F("Saving settings now..."));
     f.println(F("APIKEY=") + owmApiKey);
+    f.println(F("ntpServer=") + ntpServer);
     f.println(F("CityID=") + geoLocation); // using CityID for backwards compatibility
     f.println(F("language=") + language);
     f.println(F("marqueeMessage=") + marqueeMessage);
@@ -1947,6 +1962,10 @@ void readConfiguration() {
     }
     if ((idx = line.indexOf(F("APIKEY="))) >= 0) {
       owmApiKey = line.substring(idx + 7);
+    }
+    if ((idx = line.indexOf(F("ntpServer="))) >= 0) {
+      ntpServer = line.substring(idx + 10);
+      if (ntpServer.length() == 0) ntpServer = "pool.ntp.org";
     }
     if ((idx = line.indexOf(F("CityID="))) >= 0) {
        // using CityID for backwards compatibility

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -52,10 +52,6 @@
 #include "ESP_WiFiManager_Lite.h"
 #include "DynamicParams.h"
 
-// NTP Server
-#define NTP_SERVER_DEFAULT "pool.ntp.org"
-extern String ntpServer;
-
 //******************************
 // Hard(-ware related) settings
 //******************************

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -86,6 +86,7 @@ const int ledRotation = 3;
 //******************************
 
 String owmApiKey = ""; // Your free API Key from http://openweathermap.org/ (registration required; use Free Access for everyone )
+String ntpServer = "pool.ntp.org"; // NTP server hostname (configurable via web UI)
 // Default GEO Location (use http://openweathermap.org/find to find location name being "cityname,countrycode" or "city ID" or GPS "latitude,longitude")
 String geoLocation = "Amsterdam,NL";
 String marqueeMessage = "";

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -52,6 +52,10 @@
 #include "ESP_WiFiManager_Lite.h"
 #include "DynamicParams.h"
 
+// NTP Server
+#define NTP_SERVER_DEFAULT "pool.ntp.org"
+extern String ntpServer;
+
 //******************************
 // Hard(-ware related) settings
 //******************************

--- a/src/TimeNTP.cpp
+++ b/src/TimeNTP.cpp
@@ -18,12 +18,8 @@
 #include "TimeNTP.h"
 
 
-// NTP Servers:
-static const char ntpServerName[] = "1.pool.ntp.org";
-//static const char ntpServerName[] = "time.nist.gov";
-//static const char ntpServerName[] = "time-a.timefreq.bldrdoc.gov";
-//static const char ntpServerName[] = "time-b.timefreq.bldrdoc.gov";
-//static const char ntpServerName[] = "time-c.timefreq.bldrdoc.gov";
+// NTP Server is configurable via the web UI (stored in ntpServer in Settings.h)
+extern String ntpServer;
 
 int timeZoneSec = 0;     // UTC
 //int timeZoneSec = 1*SECS_PER_HOUR;     // Central European Time
@@ -79,8 +75,8 @@ time_t getNtpTime()
   while (Udp.parsePacket() > 0) ; // discard any previously received packets
   Serial.println(F("Transmit NTP Request"));
   // get a random server from the pool
-  WiFi.hostByName(ntpServerName, ntpServerIP);
-  Serial.print(ntpServerName);
+  WiFi.hostByName(ntpServer.c_str(), ntpServerIP);
+  Serial.print(ntpServer);
   Serial.print(": ");
   Serial.println(ntpServerIP);
   sendNTPpacket(ntpServerIP);


### PR DESCRIPTION
I have added the ability for the user to configure the NTP server used by the clock.
While I understand that this clock does not display high accuracy time, having my own stratum 1 NTP server, I wanted to pull the time locally.

Only three files modified, settings.h, TimeNTP.cpp and LEDmatrixClock.cpp.

Here's a summary of exactly what changed in each:
Settings.h — Added the global variable declaration with a sensible default:
cppString ntpServer = "pool.ntp.org";

TimeNTP.cpp — Replaced the hardcoded static const char ntpServerName[] with an extern reference to the new variable, and updated the two places it was used (hostByName() and Serial.print()) to use ntpServer.c_str().

LEDmatrixClock.cpp — Four changes:
1. Web form HTML (webChangeForm1) — Added a new "NTP Time Server" fieldset with a text input (name='ntpServer', value='%NTPSVR%') between the OWM config and the weather display options sections.
2. handleConfigure() — Added form.replace(F("%NTPSVR%"), ntpServer) to populate the field when the page loads.
3. handleSaveConfig() — Reads the ntpServer arg, trims it, falls back to pool.ntp.org if empty, and if the value actually changed, calls timeNTPsetup() so the new server takes effect immediately without a reboot.
4. writeConfiguration() / readConfiguration() — Saves and loads ntpServer= in conf.txt so the setting persists across reboots.